### PR TITLE
Add dependencies for node configuration module

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -2,6 +2,10 @@ output "private_ip" {
   value = aws_instance.this.private_ip
 }
 
+output "public_ip" {
+  value = aws_eip.this.public_ip
+}
+
 output "instance_id" {
-  value = aws_instance.this.private_ip
+  value = aws_instance.this.id
 }


### PR DESCRIPTION
Add dependencies to utilize node configuration module for citizen node.

Node configuration module will be looking for the public ip of the citizen
node from this module.

Signed-off-by: Soe San Win <soe.san.win.oss@gmail.com>